### PR TITLE
0.12.1

### DIFF
--- a/benches/memory_bench.rb
+++ b/benches/memory_bench.rb
@@ -30,7 +30,7 @@ Benchmark.ips() do |bm|
       ast = CommandSearch::Lexer.lex(input)
       CommandSearch::Parser.parse!(ast)
       CommandSearch::Optimizer.optimize!(ast)
-      CommandSearch::Normalizer.normalize!(ast, fields)
+      CommandSearch::Normalizer.normalize!(ast, fields, true)
       $hats.select { |x| CommandSearch::Memory.check(x, ast) }.count
     end
   end

--- a/benches/mongoer_bench.rb
+++ b/benches/mongoer_bench.rb
@@ -18,7 +18,7 @@ Benchmark.ips do |bm|
       ast = CommandSearch::Lexer.lex(aliased)
       CommandSearch::Parser.parse!(ast)
       CommandSearch::Optimizer.optimize!(ast)
-      CommandSearch::Normalizer.normalize!(ast, fields)
+      CommandSearch::Normalizer.normalize!(ast, fields, true)
       CommandSearch::Mongoer.build_query(ast)
     end
   end

--- a/benches/postgres_bench.rb
+++ b/benches/postgres_bench.rb
@@ -18,7 +18,7 @@ Benchmark.ips do |bm|
       ast = CommandSearch::Lexer.lex(aliased)
       CommandSearch::Parser.parse!(ast)
       CommandSearch::Optimizer.optimize!(ast)
-      CommandSearch::Normalizer.normalize!(ast, fields, false)
+      CommandSearch::Normalizer.normalize!(ast, fields)
       CommandSearch::Postgres.build_query(ast)
     end
   end

--- a/command_search.gemspec
+++ b/command_search.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'command_search'
-  s.version     = '0.12.0'
+  s.version     = '0.12.1'
 
   s.summary     = 'Let users query collections with ease.'
   s.description = 'Build powerful and friendly search APIs for users.'

--- a/lib/command_search.rb
+++ b/lib/command_search.rb
@@ -24,22 +24,22 @@ module CommandSearch
     Parser.parse!(ast)
     Optimizer.optimize!(ast)
     if type == :postgres
-      Normalizer.normalize!(ast, fields, false)
+      Normalizer.normalize!(ast, fields)
       return Postgres.build_query(ast)
     end
     if type == :sqlite
-      Normalizer.normalize!(ast, fields, false)
+      Normalizer.normalize!(ast, fields)
       return Sqlite.build_query(ast)
     end
     if type == :mysql
-      Normalizer.normalize!(ast, fields, false)
+      Normalizer.normalize!(ast, fields)
       return Mysql.build_query(ast)
     end
     if type == :mysqlV5
-      Normalizer.normalize!(ast, fields, false)
+      Normalizer.normalize!(ast, fields)
       return MysqlV5.build_query(ast)
     end
-    Normalizer.normalize!(ast, fields)
+    Normalizer.normalize!(ast, fields, true)
     return Mongoer.build_query(ast) if type == :mongo
     ast
   end

--- a/lib/command_search/backends/memory.rb
+++ b/lib/command_search/backends/memory.rb
@@ -20,6 +20,7 @@ module CommandSearch
         # item_val.to_s.match?(search)
       elsif type == Time
         item_time = item_val.to_time
+        return false if search.nil?
         search.first <= item_time && item_time < search.last
       else
         item_val == search

--- a/lib/command_search/normalizer.rb
+++ b/lib/command_search/normalizer.rb
@@ -31,8 +31,13 @@ module CommandSearch
         if times
           search_node[:value] = [times.first, times.last]
         else
-          search_node[:value] = nil
-          return
+          time_parsed = Time.parse(str) rescue nil
+          if time_parsed
+            search_node[:value] = [time_parsed, time_parsed + 1]
+          else
+            search_node[:value] = nil
+            return
+          end
         end
       end
       return unless node[:type] == :compare
@@ -114,6 +119,7 @@ module CommandSearch
       end
     end
 
+    # TODO: default to false
     def normalize!(ast, fields, cast_all = true)
       ast.map! do |node|
         if node[:type] == :and || node[:type] == :or || node[:type] == :not

--- a/lib/command_search/normalizer.rb
+++ b/lib/command_search/normalizer.rb
@@ -120,7 +120,7 @@ module CommandSearch
     end
 
     # TODO: default to false
-    def normalize!(ast, fields, cast_all = true)
+    def normalize!(ast, fields, cast_all = false)
       ast.map! do |node|
         if node[:type] == :and || node[:type] == :or || node[:type] == :not
           normalize!(node[:value], fields, cast_all)

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -18,12 +18,12 @@ Mongoid.configure do |config|
 end
 Mongo::Logger.logger.level = Logger::FATAL
 
-mysql_db_name = 'command_search_db_test'
-DB = Mysql2::Client.new(
-  host: '127.0.0.1',
-  port:  '3306',
-  username: 'root',
-)
-DB.query("DROP DATABASE IF EXISTS #{mysql_db_name}")
-DB.query("CREATE DATABASE #{mysql_db_name}")
-DB.select_db(mysql_db_name)
+# mysql_db_name = 'command_search_db_test'
+# DB = Mysql2::Client.new(
+#   host: '127.0.0.1',
+#   port:  '3306',
+#   username: 'root',
+# )
+# DB.query("DROP DATABASE IF EXISTS #{mysql_db_name}")
+# DB.query("CREATE DATABASE #{mysql_db_name}")
+# DB.select_db(mysql_db_name)

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -18,12 +18,12 @@ Mongoid.configure do |config|
 end
 Mongo::Logger.logger.level = Logger::FATAL
 
-# mysql_db_name = 'command_search_db_test'
-# DB = Mysql2::Client.new(
-#   host: '127.0.0.1',
-#   port:  '3306',
-#   username: 'root',
-# )
-# DB.query("DROP DATABASE IF EXISTS #{mysql_db_name}")
-# DB.query("CREATE DATABASE #{mysql_db_name}")
-# DB.select_db(mysql_db_name)
+mysql_db_name = 'command_search_db_test'
+DB = Mysql2::Client.new(
+  host: '127.0.0.1',
+  port:  '3306',
+  username: 'root',
+)
+DB.query("DROP DATABASE IF EXISTS #{mysql_db_name}")
+DB.query("CREATE DATABASE #{mysql_db_name}")
+DB.select_db(mysql_db_name)

--- a/spec/integration/memory_spec.rb
+++ b/spec/integration/memory_spec.rb
@@ -458,6 +458,18 @@ describe CommandSearch::Memory do
     CommandSearch.search(list4, '-foo<=1995', { fields: { foo: { type: DateTime } } }).count.should == 1
   end
 
+  it 'should handle dates BC/before-common-era' do
+    query = 'date:-0227-01-01'
+    list4 = [{ date: Time.new('1995') }]
+    CommandSearch.search(list4, query, { fields: { date: { type: DateTime } } })
+  end
+
+  it 'should not throw an error on a bad date' do
+    query = 'date:-0227-71-71'
+    list4 = [{ date: Time.new('1995') }]
+    CommandSearch.search(list4, query, { fields: { date: { type: DateTime } } })
+  end
+
   # it 'should handle searching ones that are not specified and also weird hash ones' do
   #   search('custom_s:penn').count.should == 1
   #   search('penn').count.should == 0
@@ -469,5 +481,4 @@ describe CommandSearch::Memory do
   #   search('custom_h_id:foo').count.should == 0
   #   search('custom_h.id:bar').count.should == 0
   # end
-
 end

--- a/spec/integration/mongo_spec.rb
+++ b/spec/integration/mongo_spec.rb
@@ -590,6 +590,11 @@ describe Hat do
     search_bats('fav_date<1990-01-01',   1)
   end
 
+  it 'should not throw an error on a bad date' do
+    query = 'date:-0227-71-71'
+    Hat.search(query).count.should == 0
+  end
+
   it 'should handle NOTs with commands with numbers' do
     Hat.search('feathers:0').count.should == 0
     Hat.search('-feathers:0').count.should == 9

--- a/spec/integration/postgres_spec.rb
+++ b/spec/integration/postgres_spec.rb
@@ -1,4 +1,4 @@
-load(__dir__ + '/../spec_helper.rb')
+load(__dir__ + '/integration_helper.rb')
 
 db_config = YAML.load_file(__dir__ + '/../assets/postgres.yml')
 ActiveRecord::Base.remove_connection
@@ -485,6 +485,11 @@ module PG_Spec
       Hat.search('-fav_date<=1_day_ago|fav_date<=1_day_ago').count.should == 9
       Hat.search('-fav_date<=1_day_ago|desk1').count.should == 6
       Hat.search('-fav_date<=1_day_ago|-desk1').count.should == 9
+    end
+
+    it 'should not throw an error on a bad date' do
+      query = 'date:-0227-71-71'
+      Hat.search(query).count.should == 0
     end
 
     it 'should handle nesting via parentheses' do

--- a/spec/mongoer_spec.rb
+++ b/spec/mongoer_spec.rb
@@ -6,7 +6,7 @@ describe CommandSearch::Mongoer do
     ast = CommandSearch::Lexer.lex(x)
     CommandSearch::Parser.parse!(ast)
     CommandSearch::Optimizer.optimize!(ast)
-    CommandSearch::Normalizer.normalize!(ast, fields)
+    CommandSearch::Normalizer.normalize!(ast, fields, true)
     CommandSearch::Mongoer.build_query(ast)
   end
 

--- a/spec/normalizer_spec.rb
+++ b/spec/normalizer_spec.rb
@@ -11,7 +11,7 @@ describe CommandSearch::Normalizer do
 
   def norm(x, fields)
     ast = parse(x)
-    CommandSearch::Normalizer.normalize!(ast, fields)
+    CommandSearch::Normalizer.normalize!(ast, fields, true)
     ast
   end
 


### PR DESCRIPTION
This version prevents the in memory searcher from throwing errors with invalid dates. It also adds parsing capability for more dates, or at least for dates in the format of '-0227-01-01' with a BCE/negative date.

Note that it seems BCE years are a bit funny regarding their index in ISO 8601, and also that I am not an expert on this subject. Date parsing is mostly handled by the useful but incomplete and somewhat abandoned "Chronic" gem.

https://en.wikipedia.org/wiki/Year_zero
https://en.wikipedia.org/wiki/ISO_8601#Years 